### PR TITLE
Added option to output mix metadata to JSON file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.json
 *.mp3
 *.m3u
 *.txt

--- a/README.md
+++ b/README.md
@@ -15,14 +15,15 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   --bitrate <bitrate=320k>
-                        Bitrate of output file.
+                        Bitrate of output file
   --crossfade <seconds=2>
                         Crossfade duration (in seconds).
   --fade-out <seconds=20>
                         Fade out duration (in seconds).
   --gain <dBFS=-10.0>   Target gain level for mix.
-  --intro               Intro mode (i.e. don't crossfade first track).
   --output <filename>   Path to the output file.
+  --json                Print metadata to JSON file.
+
 ```
 
 ## Installation

--- a/mixr/mixr.py
+++ b/mixr/mixr.py
@@ -1,5 +1,6 @@
 import argparse
 import datetime
+import json
 
 from pydub import AudioSegment
 from pydub.playback import play
@@ -8,14 +9,29 @@ from pydub.playback import play
 def get_default_output_name():
     return '{0}.mp3'.format(datetime.datetime.today().strftime('%b-%d-%Y-%H:%M:%S'))
 
+# Extract artist + title from each playlist entry.
+def get_audio_meta(playlist_lines):
+    # #EXTINF:345,11 2Pac - Can U Get Away (Me Against The World)
+    is_meta = lambda str: bool(str) and str.startswith('#EXTINF')
+    entries = filter(is_meta, playlist_lines)
+    # 2Pac - Can U Get Away (Me Against The World)
+    strip_headers = lambda str: str.split(' ', 1)[1]
+    entries = map(strip_headers, entries)
+    # { 'artist': '2Pac', 'title': 'Can U Get Away (Me Against The World)' }
+    create_dict = lambda entry: dict([
+        ('artist', entry.split(' - ')[0]),
+        ('title', entry.split(' - ')[1])
+    ])
+    return list(map(create_dict, entries))
+
 # Create a list of AudioSegments in the order listed in the `playlist` file.
-def get_tracks(playlist_path):
-    is_file_path = lambda str: bool(str) and str[0] is not '#'
-    with open(playlist_path) as f:
-        file_list = filter(is_file_path, f.read().split("\n"))
-        return [
-            AudioSegment.from_mp3(file_path) for file_path in file_list
-        ]
+def get_audio_segments(playlist_lines):
+    is_file_path = lambda str: bool(str) and str[0] != '#'
+    file_list = filter(is_file_path, playlist_lines)
+    return [
+        AudioSegment.from_mp3(file_path) for file_path in file_list
+    ]
+
 
 # Adjust the volume to match the target gain level.
 def normalize(sound, target_dBFS):
@@ -38,11 +54,10 @@ parser.add_argument('--fade-out', metavar='<seconds=20>', default=20,
                     type=int, help='Fade out duration (in seconds).')
 parser.add_argument('--gain', metavar='<dBFS=-10.0>', type=float, default=-10.0,
                     help='Target gain level for mix.')
-parser.add_argument('--intro', action='store_const', const=True,
-                    help='Intro mode (i.e. don\'t crossfade first track).')
 parser.add_argument('--output', metavar='<filename>',
                     default=get_default_output_name(),
                     help='Path to the output file.')
+parser.add_argument('--json', action='store_true', help='Print metadata to JSON file.')
 
 
 ###############################################################################
@@ -51,18 +66,27 @@ parser.add_argument('--output', metavar='<filename>',
 def main():
     args = parser.parse_args()
 
-    tracks = get_tracks(args.playlist)
-    mix = tracks.pop(0)
+    audio_meta = []
+    audio_segments = []
+    mix = AudioSegment.empty()
 
-    # In intro mode, add the first track without crossfading.
-    if args.intro:
-        mix = mix.append(tracks.pop(0))
+    with open(args.playlist) as f:
+        playlist_lines = f.read().split("\n")
+        audio_segments = get_audio_segments(playlist_lines)
+        if args.json:
+            audio_meta = get_audio_meta(playlist_lines)
 
-    # Concatenate remaining tracks with specified crossfade duration.
-    crossfade_duration = args.crossfade * 1000
-    for track in tracks:
-        track = normalize(track, args.gain)
-        mix = mix.append(track, crossfade=crossfade_duration)
+    # Concatenate audio_segments with specified crossfade duration.
+    for i in range(len(audio_segments)):
+        # Update audio_meta entry with track start time.
+        if args.json:
+            audio_meta[i]['start'] = len(mix)
+        # Normalize audio segment.
+        segment = audio_segments[i]
+        segment = normalize(segment, args.gain)
+        # Append segment to mix.
+        crossfade_duration = args.crossfade * 1000 if i != 0 else 0
+        mix = mix.append(segment, crossfade=crossfade_duration)
 
     # Fade the mix out.
     fadeout_duration = args.fade_out * 1000
@@ -72,6 +96,11 @@ def main():
     output = open(args.output, 'wb')
     mix.export(output, format='mp3', bitrate=args.bitrate)
     print('Mix successfully exported as: {0}'.format(args.output))
+
+    # Save JSON metadata
+    if args.json:
+        json_output = open(args.output + '.json', 'w', encoding='utf8')
+        json.dump(audio_meta, json_output)
 
 
 ###############################################################################

--- a/mixr/mixr.py
+++ b/mixr/mixr.py
@@ -47,7 +47,7 @@ parser = argparse.ArgumentParser(
 parser.add_argument('playlist', metavar='<filename>',
                     help='Path to the playlist file.')
 parser.add_argument('--bitrate', metavar='<bitrate=320k>', default='320k',
-                    type=str, help='Bitrate of output file')
+                    type=str, help='Bitrate of output file.')
 parser.add_argument('--crossfade', metavar='<seconds=2>', default=2,
                     type=int, help='Crossfade duration (in seconds).')
 parser.add_argument('--fade-out', metavar='<seconds=20>', default=20,

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
             'mixr = mixr.mixr:main'
         ] 
     }, 
-    version = '1.1.0',
+    version = '2.0.0',
     author = 'Shola Anozie',
     author_email = 'shola@soulprovidr.fm',
     install_requires = ['pydub']


### PR DESCRIPTION
Changelog
----
* Removed unused `--intro` option.
* Added `--json` option, which outputs track metadata to a JSON file:

    ```
    [
      {
        "artist": "2Pac",
        "title": "Can U Get Away (Me Against The World)",
        "start": 0
      },
      {
        "artist": "2Pac",
        "title": "Dear Mama (Me Against The World)",
        "start": 345800
      },
      {
        "artist": "2Pac",
        "title": "It Ain't Easy (Me Against The World)",
        "start": 623600
      }
    ]
    ```
* Bumped version to 2.0.0.